### PR TITLE
fix endless loop in image.parse() if find_next_segment() isn't succesful

### DIFF
--- a/include/nvjpg/bitstream.hpp
+++ b/include/nvjpg/bitstream.hpp
@@ -30,8 +30,10 @@ class Bitstream {
 
         template <typename T>
         T get() {
-            if (this->cur + sizeof(T) >= this->data.end())
+            if (this->cur + sizeof(T) >= this->data.end()) {
+                this->cur = this->data.end();
                 return {};
+            }
             auto tmp = *reinterpret_cast<const T *>(this->cur.base());
             this->cur += sizeof(T);
             return tmp;


### PR DESCRIPTION
Had a user report a bug in sphaira that it would freeze when trying to icons. The icon in question was from a `beshop.nro` which for some reason uses a png for it's icon...

Anyway, i figured that image.parse should handle trying to load an invalid jpeg. I found that it was actually freezing inside parse(). The reason is because the bitstream::get() checks if `cur + X >= end`. so if the size is 1, cur is 1 and X is 1, then it will forever be stuck inside to loop because `1 + 1 >= 2` is always true.

This fixes it by setting cur = end if that read would make it go oob. I'm not sure if this breaks anything else in the lib which maybe relies on the behaviour of reading X, expecting it to fail but not to advance cur, but i couldn't find anything. 